### PR TITLE
fix typo: cotrol -> control

### DIFF
--- a/docs/LoongArch-Vol1-EN/control-and-status-registers.adoc
+++ b/docs/LoongArch-Vol1-EN/control-and-status-registers.adoc
@@ -7,7 +7,7 @@ include::control-and-status-registers/characteristics-of-accessing-control-and-s
 
 include::control-and-status-registers/conflicts-caused-by-control-and-status-registers.adoc[]
 
-include::control-and-status-registers/basic-cotrol-and-status-registers.adoc[]
+include::control-and-status-registers/basic-control-and-status-registers.adoc[]
 
 include::control-and-status-registers/control-and-status-registers-related-to-mapped-address-translation.adoc[]
 

--- a/docs/LoongArch-Vol1-EN/control-and-status-registers/basic-cotrol-and-status-registers.adoc
+++ b/docs/LoongArch-Vol1-EN/control-and-status-registers/basic-cotrol-and-status-registers.adoc
@@ -1,42 +1,42 @@
-[[basic-cotrol-and-status-registers]]
-=== Basic Cotrol and Status Registers
+[[basic-control-and-status-registers]]
+=== Basic Control and Status Registers
 
-include::basic-cotrol-and-status-registers/current-mode-information.adoc[]
+include::basic-control-and-status-registers/current-mode-information.adoc[]
 
-include::basic-cotrol-and-status-registers/pre-exception-mode-information.adoc[]
+include::basic-control-and-status-registers/pre-exception-mode-information.adoc[]
 
-include::basic-cotrol-and-status-registers/extended-component-unit-enable.adoc[]
+include::basic-control-and-status-registers/extended-component-unit-enable.adoc[]
 
-include::basic-cotrol-and-status-registers/miscellaneous-controller.adoc[]
+include::basic-control-and-status-registers/miscellaneous-controller.adoc[]
 
-include::basic-cotrol-and-status-registers/exception-configuration.adoc[]
+include::basic-control-and-status-registers/exception-configuration.adoc[]
 
-include::basic-cotrol-and-status-registers/exception-status.adoc[]
+include::basic-control-and-status-registers/exception-status.adoc[]
 
-include::basic-cotrol-and-status-registers/exception-return-address.adoc[]
+include::basic-control-and-status-registers/exception-return-address.adoc[]
 
-include::basic-cotrol-and-status-registers/bad-virtual-address.adoc[]
+include::basic-control-and-status-registers/bad-virtual-address.adoc[]
 
-include::basic-cotrol-and-status-registers/bad-instruction.adoc[]
+include::basic-control-and-status-registers/bad-instruction.adoc[]
 
-include::basic-cotrol-and-status-registers/exception-entry-base-address.adoc[]
+include::basic-control-and-status-registers/exception-entry-base-address.adoc[]
 
-include::basic-cotrol-and-status-registers/reduced-virtual-address-configuration.adoc[]
+include::basic-control-and-status-registers/reduced-virtual-address-configuration.adoc[]
 
-include::basic-cotrol-and-status-registers/cpu-identity.adoc[]
+include::basic-control-and-status-registers/cpu-identity.adoc[]
 
-include::basic-cotrol-and-status-registers/privileged-resource-configuration-1.adoc[]
+include::basic-control-and-status-registers/privileged-resource-configuration-1.adoc[]
 
-include::basic-cotrol-and-status-registers/privileged-resource-configuration-2.adoc[]
+include::basic-control-and-status-registers/privileged-resource-configuration-2.adoc[]
 
-include::basic-cotrol-and-status-registers/privileged-resource-configuration-3.adoc[]
+include::basic-control-and-status-registers/privileged-resource-configuration-3.adoc[]
 
-include::basic-cotrol-and-status-registers/data-save-register.adoc[]
+include::basic-control-and-status-registers/data-save-register.adoc[]
 
-include::basic-cotrol-and-status-registers/llbit-controller.adoc[]
+include::basic-control-and-status-registers/llbit-controller.adoc[]
 
-include::basic-cotrol-and-status-registers/implementation-specific-controller-1.adoc[]
+include::basic-control-and-status-registers/implementation-specific-controller-1.adoc[]
 
-include::basic-cotrol-and-status-registers/implementation-specific-controller-2.adoc[]
+include::basic-control-and-status-registers/implementation-specific-controller-2.adoc[]
 
-include::basic-cotrol-and-status-registers/cache-tags.adoc[]
+include::basic-control-and-status-registers/cache-tags.adoc[]

--- a/docs/LoongArch-Vol1-EN/storage-management/storage-management-of-page-table-mapping/software-management-of-tlb.adoc
+++ b/docs/LoongArch-Vol1-EN/storage-management/storage-management-of-page-table-mapping/software-management-of-tlb.adoc
@@ -73,7 +73,7 @@ The third category includes:
 * `TLBRPRMD`
 * `TLBRSAVE`
 
-See <<basic-cotrol-and-status-registers,Basic Cotrol and Status Registers>> for details of how each CSR register above interacts with the TLB.
+See <<basic-control-and-status-registers,Basic Control and Status Registers>> for details of how each CSR register above interacts with the TLB.
 
 ===== Initialization of TLB
 


### PR DESCRIPTION
Just fixing a small typo in some headers: `cotrol` is misspelled, should be `control`.