### PR TITLE
fix translation of the consequence of "rd = rj" for am* instructions

### DIFF
--- a/docs/LoongArch-Vol1-EN/basic-integer-instructions/overview-of-basic-integer-instructions/atomic-memory-access-instructions.adoc
+++ b/docs/LoongArch-Vol1-EN/basic-integer-instructions/overview-of-basic-integer-instructions/atomic-memory-access-instructions.adoc
@@ -71,7 +71,7 @@ The new value written to memory is the minimum value obtained by comparing the o
 `AM*_DB.W[U]/D[U]` instruction not only completes the above atomized operation sequence, but also implements the data barrier function at the same time.
 That is, all access operations preceding the atomic access instruction in the same processor core are completed before such atomic access instructions are allowed to be executed, and all access operations following the atomic access instruction in the same processor core are allowed to be executed only after such atomic access instructions are executed.
 
-If the `AM*` atomic memory access instruction has the same register number as `rd` and `rj`, there is no exception for the trigger instruction.
+If the `AM*` atomic memory access instruction has the same register number as `rd` and `rj`, the execution will trigger an Instruction Non-defined Exception.
 
 If the `AM*` atomic memory access instruction has the same register number as `rd` and `rk`, the execution result is uncertain.
 Please software to avoid this situation.


### PR DESCRIPTION
原文是：

     AM* 原子访存指令如果 rd 和 rj 的寄存器号相同，则触发指令不存在例外。

正确的断句是 “则触发/指令不存在例外” (实测也确实是这样的)，然而翻译成英文的时候断成了“则触发指令/不存在例外”。

```
# cat t.c
int main()
{
        __asm__("amswap.w $r0, $r12, $r0");
}
# cc t.c && ./a.out 
Illegal instruction (core dumped)
# 
```