### PR TITLE
Document: Add SMBIOS additional Information for LoongArch

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -47,3 +47,6 @@ To make it easier to download, each HTML page contains embedded CSS and images.
 * LoongArch ELF ABI: This manual describes the LoongArch ELF ABI.
 ** https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html[HTML version].
 ** https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.pdf[PDF version].
+
+* LoongArch Processor SMBIOS Spec: This document introduces additional information about LoongArch in SMBIOS.
+** https://loongson.github.io/LoongArch-Documentation/LoongArch-Processor-SMBIOS-Spec-EN.html[HTML version].

--- a/docs/LoongArch-Processor-SMBIOS-Spec-EN.adoc
+++ b/docs/LoongArch-Processor-SMBIOS-Spec-EN.adoc
@@ -1,0 +1,74 @@
+= LoongArch Processor SMBIOS Spec
+Loongson Technology Corporation Limited
+v1.00
+:docinfodir: ../themes
+:docinfo: shared
+:doctype: book
+:toc: left
+
+This document defines LoongArch processor-specific data block to supplement the upstream definition of SMBIOS structure Type 44 (Processor Additional Information, section 7.45 in SMBIOS specification V3.5.0 or later).
+
+=== Symbols
+
+* *DQWORD* +
+128-bits (In the SMBIOS specification, WORD is 16-bits, DWORD is 32-bits, and QWORD is 64-bits).
+
+
+=== Vendor Name register and CPU Name register
+
+The LoongArch CPUs designed by Loongson have two registers representing Machine Vendor Name and CPU Name, both of which are DQWORD-format NUL-terminated ASCII string values, located at offsets 0x10 and 0x20 of the IOCSR space respectively.
+
+=== LoongArch Processor-specific Block Structure
+[%header,cols="^1,^1,^1,^1,3"]
+|===
+|Offset
+|Name
+|Length
+|Value
+^|Description
+
+|00h
+|Block Length
+|BYTE
+|Varies (N)
+|Length of Processor-specific Data
+
+|01h
+|Processor Type
+|BYTE
+|Varies
+|The processor architecture delineated by this Processor-specific Block (See SMBIOS Table 131). 0x9 means LoongArch32 and 0x10 means LoongArch64.
+
+|02h
+|Processor-Specific Data
+|N BYTEs
+|Varies
+|Processor-specific data.
+
+|03h
+|Reserved
+|BYTE
+|Varies
+|Reserved.
+
+|04h
+|Machine Vendor ID
+|DQWORD
+|Varies
+|The manufacturer vendor ID of the processor. +
+It is semantically equivalent to the value at the offset 0x10 of the IOCSR space on a Loongson CPU.
+
+|14h
+|CPU ID
+|DQWORD
+|Varies
+|The CPU ID used for this LoongArch processor manufacturer to mark different CPU types or CPU instances. +
+It is semantically equivalent to the value at the offset 0x20 of the IOCSR space on a Loongson CPU.
+
+|24h
+|ISA extensions support
+|DWORD
+|Bit-field
+|The bit field [3:0] indicates support for the existing LoongArch standard ISA extensions. It is modeled after the LoongArch EUEN register (CSR 0x2), and meaning of each bit is the same as defined for the EUEN register. +
+Setting a bit in this field indicates that this system supports the corresponding ISA extension.
+|===

--- a/docs/README-CN.adoc
+++ b/docs/README-CN.adoc
@@ -43,6 +43,10 @@
 ** link:LoongArch-toolchain-conventions-CN.html[HTML 版本]。
 ** link:LoongArch-toolchain-conventions-CN.pdf[PDF 版本]。
 
+* 龙芯架构 SMBIOS 规范：该文档定义了龙芯架构处理器附加信息，是 SMBIOS 结构 type 44 的补充。本文档仅提供 *英文版*。
+** link:LoongArch-Processor-SMBIOS-Spec-EN.html[HTML 版本]。
+
+
 [[getting-start]]
 == 开始
 

--- a/docs/README-EN.adoc
+++ b/docs/README-EN.adoc
@@ -51,6 +51,9 @@ To make it easier to download, each HTML page contains embedded CSS and images.
 ** link:LoongArch-toolchain-conventions-EN.html[HTML version].
 ** link:LoongArch-toolchain-conventions-EN.pdf[PDF version].
 
+* LoongArch Processor SMBIOS Spec: This document introduces additional information about LoongArch in SMBIOS.
+** link:LoongArch-Processor-SMBIOS-Spec-EN.html[HTML version].
+
 == Translator`'s Note
 
 Due to the limited knowledge of the translators, there are some inevitable errors and omissions existing in this document, please feel free to correct.


### PR DESCRIPTION
There is no standard table in the Type 44 in section 7.45 of SMBIOS.
It needs an external table to describe the additional information.