### PR TITLE
Fix mistake in FCLASS instruction puesdocode

### DIFF
--- a/docs/LoongArch-Vol1-EN/basic-floating-point-instructions/overview-of-floating-point-instructions/floating-point-arithmetic-operation-instructions.adoc
+++ b/docs/LoongArch-Vol1-EN/basic-floating-point-instructions/overview-of-floating-point-instructions/floating-point-arithmetic-operation-instructions.adoc
@@ -398,5 +398,4 @@ FCLASS.S:
 
 FCLASS.D:
     FR[fd] = FP64_class(FR[fj])
-    sedMultiplyAdd(FR[fj], FR[fk], FR[fa])
 ----


### PR DESCRIPTION
The description for the FCLASS instruction seems to have a mistake, as it is unlikely a fused multiply add would be done in that instruction, and that line is not present in the Chinese version of the specification
