### PR TITLE
Adjust the Multiarch Specifier

### DIFF
--- a/docs/LoongArch-toolchain-conventions-CN.adoc
+++ b/docs/LoongArch-toolchain-conventions-CN.adoc
@@ -294,9 +294,9 @@ ABI 配置的需要。若不能，则应根据下表，在默认可用指令集�
 [%header,cols="^1,^2"]
 |===
 |`<fabi_suffix>` 字符串    |含义
-|`f64`                     |基础 ABI 使用 64 位浮点寄存器传参 (`lp64d` `ilp32d`)
-|`f32`                     |基础 ABI 使用 32 位浮点寄存器传参 (`lp64f` `ilp32f`)
-|`sf`                      |基础 ABI 不使用浮点寄存器传参 (`lp64s` `ilp32s`)
+|（空）                    |基础 ABI 使用 64 位浮点寄存器传参 (`lp64d`)
+|`f32`                     |基础 ABI 使用 32 位浮点寄存器传参 (`lp64f`)
+|`sf`                      |基础 ABI 不使用浮点寄存器传参 (`lp64s`)
 |===
 
 .Multiarch `os` 字段，`<abiext_suffix>` 后缀标记及其对应的 ABI 扩展特性
@@ -315,7 +315,7 @@ ABI 配置的需要。若不能，则应根据下表，在默认可用指令集�
 
 |`lp64d` / `base`
 | glibc | Linux
-|`loongarch64-linux-gnuf64`
+|`loongarch64-linux-gnu`
 
 |`lp64f` / `base`
 | glibc | Linux
@@ -325,21 +325,9 @@ ABI 配置的需要。若不能，则应根据下表，在默认可用指令集�
 | glibc | Linux
 |`loongarch64-linux-gnusf`
 
-|`ilp32d` / `base`
-| glibc | Linux
-|`loongarch32-linux-gnuf64`
-
-|`ilp32f` / `base`
-| glibc | Linux
-|`loongarch32-linux-gnuf32`
-
-|`ilp32s` / `base`
-| glibc | Linux
-|`loongarch32-linux-gnusf`
-
 |`lp64d` / `base`
 | musl libc | Linux
-|`loongarch64-linux-muslf64`
+|`loongarch64-linux-musl`
 
 |`lp64f` / `base`
 | musl libc | Linux
@@ -348,18 +336,6 @@ ABI 配置的需要。若不能，则应根据下表，在默认可用指令集�
 |`lp64s` / `base`
 | musl libc | Linux
 |`loongarch64-linux-muslsf`
-
-|`ilp32d` / `base`
-| musl libc | Linux
-|`loongarch32-linux-muslf64`
-
-|`ilp32f` / `base`
-| musl libc | Linux
-|`loongarch32-linux-muslf32`
-
-|`ilp32s` / `base`
-| musl libc | Linux
-|`loongarch32-linux-muslsf`
 |===
 
 

--- a/docs/LoongArch-toolchain-conventions-EN.adoc
+++ b/docs/LoongArch-toolchain-conventions-EN.adoc
@@ -335,9 +335,9 @@ specifier, respectively.
 [%header,cols="^1,^2"]
 |===
 |`<fabi-suffix>` |Description
-|`f64`           |The base ABI uses 64-bit FPRs for parameter passing. (`lp64d` `ilp32d`)
-|`f32`           |The base ABI uses 32-bit FPRs for parameter passing. (`lp64f` `ilp32f`)
-|`sf`            |The base ABI uses no FPR for parameter passing. (`lp64s` `ilp32s`)
+|(empty string)  |The base ABI uses 64-bit FPRs for parameter passing. (`lp64d`)
+|`f32`           |The base ABI uses 32-bit FPRs for parameter passing. (`lp64f`)
+|`sf`            |The base ABI uses no FPR for parameter passing. (`lp64s`)
 |===
 
 .List of possible `<abiext-suffix>`
@@ -360,7 +360,7 @@ multiple multiarch specifiers for one OS / ABI combination.)__
 
 |`lp64d` / `base`
 | glibc | Linux
-|`loongarch64-linux-gnuf64`
+|`loongarch64-linux-gnu`
 
 |`lp64f` / `base`
 | glibc | Linux
@@ -370,21 +370,9 @@ multiple multiarch specifiers for one OS / ABI combination.)__
 | glibc | Linux
 |`loongarch64-linux-gnusf`
 
-|`ilp32d` / `base`
-| glibc | Linux
-|`loongarch32-linux-gnuf64`
-
-|`ilp32f` / `base`
-| glibc | Linux
-|`loongarch32-linux-gnuf32`
-
-|`ilp32s` / `base`
-| glibc | Linux
-|`loongarch32-linux-gnusf`
-
 |`lp64d` / `base`
 | musl libc | Linux
-|`loongarch64-linux-muslf64`
+|`loongarch64-linux-musl`
 
 |`lp64f` / `base`
 | musl libc | Linux
@@ -393,18 +381,6 @@ multiple multiarch specifiers for one OS / ABI combination.)__
 |`lp64s` / `base`
 | musl libc | Linux
 |`loongarch64-linux-muslsf`
-
-|`ilp32d` / `base`
-| musl libc | Linux
-|`loongarch32-linux-muslf64`
-
-|`ilp32f` / `base`
-| musl libc | Linux
-|`loongarch32-linux-muslf32`
-
-|`ilp32s` / `base`
-| musl libc | Linux
-|`loongarch32-linux-muslsf`
 |===
 
 == C/C++ Preprocessor Built-in Macro Definitions


### PR DESCRIPTION
# Changes
- Replace loongarch64-linux-gnuf64 with loongarch64-linux-gnu.
- Remove all loongarch32 multiarch specifiers.

# Several reasons for making the changes
- "f64" indicates the generic purpose ABI variant. So "gnuf64" seems unnecessary - can be replaced with "gnu". We see a related discussion in llvm [1]. And gnu is adopted by many popular archs [2].
- There is no 32-bit LoongArch chips and operating systems at present and we are not sure whether 32-bit hardware is allowed or necessary to support 64-bit floating-point. So it's better not define the tuples for now.

[1]. https://reviews.llvm.org/D135751#3851867
[2]. https://wiki.debian.org/Multiarch/Tuples